### PR TITLE
Use modal window to display users that reacted

### DIFF
--- a/demos/project-stories/project_stories/project_stories/settings.py
+++ b/demos/project-stories/project_stories/project_stories/settings.py
@@ -253,12 +253,9 @@ COMMENTS_INK_APP_MODEL_OPTIONS = {
 # selector to the following setting.
 COMMENTS_INK_CSS_CUSTOM_SELECTOR = "dci dci-custom"
 
-# How many users are listed when hovering a reaction.
-COMMENTS_INK_MAX_USERS_IN_TOOLTIP = 5
-
 # The theme dir, corresponds with any of the directories listed
 # with the template directory: comments/themes/<theme_dir>.
-COMMENTS_INK_THEME_DIR = ""
+COMMENTS_INK_THEME_DIR = "avatar_in_header"
 
 COMMENTS_INK_COMMENT_REACTIONS_ENUM = (
     "project_stories.enums.CommentReactionEnum"

--- a/demos/project-stories/project_stories/static/main.css
+++ b/demos/project-stories/project_stories/static/main.css
@@ -745,3 +745,15 @@ UL.small LI {
 .dci.dci-custom .comment-box-img .body.bordered {
     padding: 4px;
 }
+
+.users-grid > div {
+    background-color: #d5ecff;
+    padding: 0.5em 1em;
+    border-radius: 0.5em;
+    font-size: 0.9rem;
+}
+
+.dci .pagination.pagination-modal {
+    padding-bottom: 0px;
+    font-size: 0.9rem;
+}

--- a/demos/project-stories/project_stories/static/modal.css
+++ b/demos/project-stories/project_stories/static/modal.css
@@ -23,7 +23,7 @@
 
 .modal__header {
     /* Optional */
-    padding: 1.5rem;
+    padding: 1.2rem;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -54,7 +54,7 @@
     overflow: visible;
     opacity: 0;
     /* max-width set here below as in main.css ".container" width */
-    max-height: 80vh;
+    max-height: 82vh;
 
     transition: transform 0.2s, opacity 0.2s;
     will-change: transform;
@@ -77,7 +77,7 @@
         max-width: 732px;
     }
     .modal__wrapper .container {
-        width: calc(732px - 3rem);
+        width: calc(732px - 2.4rem);
     }
 }
 
@@ -100,9 +100,9 @@
 .modal.is-active {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     position: fixed;
-    top: 0;
+    top: 4vw;
     right: 0;
     left: 0;
     bottom: 0;

--- a/demos/project-stories/project_stories/static/modal.css
+++ b/demos/project-stories/project_stories/static/modal.css
@@ -1,0 +1,120 @@
+.modal {
+    display: none;
+}
+
+.modal__overlay {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: 200;
+    opacity: 0;
+
+    transition: opacity 0.2s;
+    will-change: opacity;
+    background-color: #000;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.modal__header {
+    /* Optional */
+    padding: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #ddd;
+}
+
+.modal__close {
+    position: absolute;
+    top: 0;
+    right: 0;
+    font-size: 2rem;
+    padding: 0px 12px 4px;
+    margin: -26px -22px 0 0;
+    border: none;
+    color: white;
+    background: #2196f3;
+    cursor: pointer;
+}
+
+.modal__close:hover, .modal__close:not(.disabled):hover {
+    margin-top: -26px;
+    border-bottom-width: none;
+}
+
+.modal__wrapper {
+    width: 100%;
+    z-index: 9999;
+    overflow: visible;
+    opacity: 0;
+    /* max-width set here below as in main.css ".container" width */
+    max-height: 80vh;
+
+    transition: transform 0.2s, opacity 0.2s;
+    will-change: transform;
+    background-color: #fff;
+
+    display: flex;
+    flex-direction: column;
+    -webkit-transform: translateY(5%);
+    transform: translateY(5%);
+
+    -webkit-overflow-scrolling: touch;
+    /* Enables momentum scrolling in iOS overflow elements. */
+    box-shadow: 0 2px 6px #777;
+    border-radius: 5px;
+    margin: 20px;
+}
+
+@media screen and (min-width: 840px) {
+    .modal__wrapper {
+        max-width: 732px;
+    }
+    .modal__wrapper .container {
+        width: calc(732px - 3rem);
+    }
+}
+
+@media screen and (max-width: 839px) {
+    .modal__wrapper {
+        max-width: 80vw;
+    }
+}
+
+.modal__content {
+    position: relative;
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: 100%;
+    flex-grow: 1;
+    /* Optional */
+    padding: 1.5rem;
+}
+
+.modal.is-active {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    right: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 9999;
+}
+
+.modal.is-visible .modal__wrapper {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+}
+
+.modal.is-visible .modal__overlay {
+    opacity: 0.5;
+}

--- a/demos/project-stories/project_stories/static/modal.js
+++ b/demos/project-stories/project_stories/static/modal.js
@@ -43,7 +43,10 @@ const init_modals = function() {
         );
     };
 
-    const addPaginationLinks = function() {
+    const addModalListeners = function() {
+        document.querySelectorAll(settings.selectorClose).forEach(
+            elem => elem.addEventListener('click', clickHandler, false)
+        );
         const pagLinks = document.querySelectorAll(settings.selectorReload);
         pagLinks.forEach(
             elem => elem.addEventListener('click', reloadContent, false)
@@ -61,10 +64,10 @@ const init_modals = function() {
         const response = await fetch(trigger.dataset.href, {method: 'GET'});
         if (response.status === 200) {
             const data = await response.text();
-            const body = target && target.querySelector(".modal2__content");
+            const body = target && target.querySelector(".modal__wrapper");
             if (body) {
                 body.innerHTML = data;
-                addPaginationLinks();
+                addModalListeners();
             }
         }
     };
@@ -103,10 +106,6 @@ const init_modals = function() {
     document.querySelectorAll(settings.selectorTrigger).forEach(
         elem => elem.addEventListener('click', clickHandler, false)
     );
-    document.querySelectorAll(settings.selectorClose).forEach(
-        elem => elem.addEventListener('click', clickHandler, false)
-    );
-
     document.addEventListener('keydown', keydownHandler, false);
 };
 

--- a/demos/project-stories/project_stories/static/modal.js
+++ b/demos/project-stories/project_stories/static/modal.js
@@ -1,0 +1,115 @@
+const init_modals = function() {
+    const settings = {
+        speedOpen: 50,
+        speedClose: 250,
+        activeClass: 'is-active',
+        visibleClass: 'is-visible',
+        selectorTarget: '[data-modal-target]',
+        selectorReload: '[data-modal-reload]',
+        selectorTrigger: '[data-modal-trigger]',
+        selectorClose: '[data-modal-close]',
+    };
+
+    const toggleccessibility = function(event) {
+        if (event.getAttribute('aria-expanded') === 'true') {
+            event.setAttribute('aria-expanded', false);
+        } else {
+            event.setAttribute('aria-expanded', true);
+        }
+    };
+
+    const openModal = function(trigger) {
+        const controls = trigger.getAttribute('aria-controls');
+        const target = document.getElementById(controls);
+        target.classList.add(settings.activeClass);
+        document.documentElement.style.overflow = 'hidden';
+        toggleccessibility(trigger);
+        setTimeout(
+            () => target.classList.add(settings.visibleClass),
+            settings.speedOpen
+        );
+    };
+
+    const closeModal = function(event) {
+        const closestParent = event.closest(settings.selectorTarget);
+        const controls = '[aria-controls="' + closestParent.id + '"]';
+        const childrenTrigger = document.querySelector(controls);
+        closestParent.classList.remove(settings.visibleClass);
+        document.documentElement.style.overflow = '';
+        toggleccessibility(childrenTrigger);
+        setTimeout(
+            () => closestParent.classList.remove(settings.activeClass),
+            settings.speedClose
+        );
+    };
+
+    const addPaginationLinks = function() {
+        const pagLinks = document.querySelectorAll(settings.selectorReload);
+        pagLinks.forEach(
+            elem => elem.addEventListener('click', reloadContent, false)
+        );
+    };
+
+    const reloadContent = async function(event) {
+        const target = event.target;
+        await loadContent(target);
+    };
+
+    const loadContent = async function(trigger) {
+        const controls = trigger.getAttribute('aria-controls');
+        const target = document.getElementById(controls);
+        const response = await fetch(trigger.dataset.href, {method: 'GET'});
+        if (response.status === 200) {
+            const data = await response.text();
+            const body = target && target.querySelector(".modal2__content");
+            if (body) {
+                body.innerHTML = data;
+                addPaginationLinks();
+            }
+        }
+    };
+
+    const clickHandler = async function(event) {
+        const toggle = event.target;
+        const open = toggle.closest(settings.selectorTrigger);
+        const close = toggle.closest(settings.selectorClose);
+
+        if (open) { // Open modal when the open button is clicked.
+            await loadContent(open);
+            openModal(open);
+        }
+
+        if (close) { // Close modal when the close button is clicked.
+            closeModal(close);
+        }
+
+        if (open || close) { // Prevent default link behavior.
+            event.preventDefault();
+        }
+    };
+
+    // Keydown Handler, handle Escape button
+    const keydownHandler = function(event) {
+        if (event.key === 'Escape' || event.keyCode === 27) {
+            const mWins = document.querySelectorAll(settings.selectorTarget);
+            for (let i = 0; i < mWins.length; ++i) {
+                if (mWins[i].classList.contains(settings.activeClass)) {
+                    closeModal(mWins[i]);
+                }
+            }
+        }
+    };
+
+    document.querySelectorAll(settings.selectorTrigger).forEach(
+        elem => elem.addEventListener('click', clickHandler, false)
+    );
+    document.querySelectorAll(settings.selectorClose).forEach(
+        elem => elem.addEventListener('click', clickHandler, false)
+    );
+
+    document.addEventListener('keydown', keydownHandler, false);
+};
+
+window.addEventListener("DOMContentLoaded", (_) => {
+    init_modals();
+});

--- a/demos/project-stories/project_stories/templates/base.html
+++ b/demos/project-stories/project_stories/templates/base.html
@@ -76,6 +76,9 @@
       </div>
     </footer>
 
+    {% block extra_html %}
+    {% endblock %}
+
     <script src="{% url 'javascript-catalog' %}"></script>
     <script src="{% static 'dropdown.js' %}"></script>
     <script src="{% static 'init_language_dropdown.js' %}"></script>

--- a/demos/project-stories/project_stories/templates/comments/list_reacted.html
+++ b/demos/project-stories/project_stories/templates/comments/list_reacted.html
@@ -1,0 +1,40 @@
+{% load i18n %}
+{% load comments_ink %}
+
+<button class="modal__close" data-modal-close aria-label="Close Modal">&times;</button>
+<div class="modal__header">
+  <div class="modal__title">
+    {% blocktrans with reaction_icon=reaction.icon comment_author=comment.user_name %}List of users that reacted with <span class="emoji">&{{ reaction_icon }};</span><br/>to {{ comment_author }} comment{% endblocktrans %}
+  </div>
+</div>
+<div class="modal__content">
+  <div class="central-column" id="users">
+    <div class="{% dci_custom_selector %}">
+      <div class="users-grid">
+        {% for author_name in page_obj %}
+          <div>{{ author_name }}</div>
+        {% endfor %}
+      </div>
+
+      {% if page_obj.paginator.num_pages > 1 %}
+        <div class="inline-centered pagination pagination-modal">
+          <span class="step-links">
+            {% if page_obj.has_previous %}
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted' comment.id reaction.value %}?page=1#users" href="#">&laquo; first</a>
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted' comment.id reaction.value %}?page={{ page_obj.previous_page_number }}#users" href="#">previous</a>
+            {% endif %}
+
+            <span class="current">
+              Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+            </span>
+
+            {% if page_obj.has_next %}
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted' comment.id reaction.value %}?page={{ page_obj.next_page_number }}#users" href="#">next</a>
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted' comment.id reaction.value %}?page={{ page_obj.paginator.num_pages }}#users" href="#">last &raquo;</a>
+            {% endif %}
+          </span>
+        </div>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/demos/project-stories/project_stories/templates/comments/list_reacted_to_object.html
+++ b/demos/project-stories/project_stories/templates/comments/list_reacted_to_object.html
@@ -1,35 +1,40 @@
 {% load i18n %}
 {% load comments_ink %}
 
-<div class="container">
-  <h4 class="text-center">{% blocktrans with reaction_icon=reaction.icon %}List of users that reacted with <span class="emoji">&{{ reaction_icon }};</span> to{% endblocktrans %}<br/><span id="users"></span><a href="{{ object.get_absolute_url }}">{{ object }}</a></h4>
+<button class="modal__close" data-modal-close aria-label="Close Modal">&times;</button>
+<div class="modal__header">
+  <div class="modal__title">
+    {% blocktrans with reaction_icon=reaction.icon %}List of users that reacted with <span class="emoji">&{{ reaction_icon }};</span> to<br/>{{ object }}{% endblocktrans %}
+  </div>
 </div>
-<div class="central-column">
-  <div class="{% dci_custom_selector %} mt32 xpb32">
-    <div class="users-grid">
-      {% for author_name in page_obj %}
-        <div>{{ author_name }}</div>
-      {% endfor %}
-    </div>
-
-    {% if page_obj.paginator.num_pages > 1 %}
-      <div class="inline-centered pagination">
-        <span class="step-links">
-          {% if page_obj.has_previous %}
-            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page=1#users" href="#">&laquo; first</a>
-            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.previous_page_number }}#users">previous</a>
-          {% endif %}
-
-          <span class="current">
-            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
-          </span>
-
-          {% if page_obj.has_next %}
-            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.next_page_number }}#users" href="#">next</a>
-            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.paginator.num_pages }}#users" href="#">last &raquo;</a>
-          {% endif %}
-        </span>
+<div class="modal__content">
+  <div class="central-column" id="users">
+    <div class="{% dci_custom_selector %}">
+      <div class="users-grid">
+        {% for author_name in page_obj %}
+          <div>{{ author_name }}</div>
+        {% endfor %}
       </div>
-    {% endif %}
+
+      {% if page_obj.paginator.num_pages > 1 %}
+        <div class="inline-centered pagination pagination-modal">
+          <span class="step-links">
+            {% if page_obj.has_previous %}
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page=1#users" href="#">&laquo; first</a>
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.previous_page_number }}#users">previous</a>
+            {% endif %}
+
+            <span class="current">
+              Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+            </span>
+
+            {% if page_obj.has_next %}
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.next_page_number }}#users" href="#">next</a>
+              <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.paginator.num_pages }}#users" href="#">last &raquo;</a>
+            {% endif %}
+          </span>
+        </div>
+      {% endif %}
+    </div>
   </div>
 </div>

--- a/demos/project-stories/project_stories/templates/comments/list_reacted_to_object.html
+++ b/demos/project-stories/project_stories/templates/comments/list_reacted_to_object.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+{% load comments_ink %}
+
+<div class="container">
+  <h4 class="text-center">{% blocktrans with reaction_icon=reaction.icon %}List of users that reacted with <span class="emoji">&{{ reaction_icon }};</span> to{% endblocktrans %}<br/><span id="users"></span><a href="{{ object.get_absolute_url }}">{{ object }}</a></h4>
+</div>
+<div class="central-column">
+  <div class="{% dci_custom_selector %} mt32 xpb32">
+    <div class="users-grid">
+      {% for author_name in page_obj %}
+        <div>{{ author_name }}</div>
+      {% endfor %}
+    </div>
+
+    {% if page_obj.paginator.num_pages > 1 %}
+      <div class="inline-centered pagination">
+        <span class="step-links">
+          {% if page_obj.has_previous %}
+            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page=1#users" href="#">&laquo; first</a>
+            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.previous_page_number }}#users">previous</a>
+          {% endif %}
+
+          <span class="current">
+            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+          </span>
+
+          {% if page_obj.has_next %}
+            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.next_page_number }}#users" href="#">next</a>
+            <a data-modal-reload aria-controls="list-reacted" aria-expanded="true" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}?page={{ page_obj.paginator.num_pages }}#users" href="#">last &raquo;</a>
+          {% endif %}
+        </span>
+      </div>
+    {% endif %}
+  </div>
+</div>

--- a/demos/project-stories/project_stories/templates/comments/object_reactions_form.html
+++ b/demos/project-stories/project_stories/templates/comments/object_reactions_form.html
@@ -11,7 +11,7 @@
       {% for reaction in object_reactions %}
         <button type="submit" class="emoji" name="reaction" id="{{ reaction.value }}" value="{{ reaction.value }}">&{{ reaction.icon }};</button>&nbsp;
         <span class="reaction">
-          {% if reaction.counter > max_users_in_tooltip %}<a href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}">{{ reaction.counter }}</a>{% else %}<span>{{ reaction.counter }}</span>{% endif %}
+          {% if reaction.counter > max_users_in_tooltip %}<a data-modal-trigger aria-controls="list-reacted" aria-expanded="false" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}" href="#">{{ reaction.counter }}</a>{% else %}<span>{{ reaction.counter }}</span>{% endif %}
           <div class="reaction_tooltip small">{% if reaction.counter > 0 and reaction.counter > reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} and more reacted with {{ label }}{% endblocktrans %}{% elif reaction.counter > 0 and reaction.counter == reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} reacted with {{ label }}{% endblocktrans %}{% else %}{% blocktrans with label=reaction.label %}Nobody reacted yet with {{ label }}{% endblocktrans %}{% endif %}</div>
         </span>
         {% if not forloop.last %}&nbsp;&nbsp;&nbsp;{% endif %}
@@ -37,7 +37,7 @@
       {% if reaction.counter %}
         <span class="emoji">&{{ reaction.icon }};</span>&nbsp;&nbsp;
         <span class="reaction">
-          {% if reaction.counter > max_users_in_tooltip %}<a href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}">{{ reaction.counter }}</a>{% else %}<span>{{ reaction.counter }}</span>{% endif %}
+          {% if reaction.counter > max_users_in_tooltip %}<a data-modal-trigger aria-controls="list-reacted" aria-expanded="false" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}" href="#">{{ reaction.counter }}</a>{% else %}<span>{{ reaction.counter }}</span>{% endif %}
           <div class="reaction_tooltip small">{% if reaction.counter > 0 and reaction.counter > reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} and more reacted with {{ label }}{% endblocktrans %}{% elif reaction.counter > 0 and reaction.counter == reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} reacted with {{ label }}{% endblocktrans %}{% else %}{% blocktrans with label=reaction.label %}Nobody reacted yet with {{ label }}{% endblocktrans %}{% endif %}</div>
         </span>
         {% if not forloop.last %}&nbsp;&nbsp;&nbsp;{% endif %}

--- a/demos/project-stories/project_stories/templates/comments/object_reactions_form.html
+++ b/demos/project-stories/project_stories/templates/comments/object_reactions_form.html
@@ -25,7 +25,7 @@
         <span class="emoji">&{{ reaction.icon }};</span>
       </a>&nbsp;&nbsp;
       <span class="reaction">
-        {% if reaction.counter > max_users_in_tooltip %}<a href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}">{{ reaction.counter }}</a>{% else %}<span>{{ reaction.counter }}</span>{% endif %}
+        {% if reaction.counter > max_users_in_tooltip %}<a data-modal-trigger aria-controls="list-reacted" aria-expanded="false" data-href="{% url 'comments-ink-list-reacted-to-object' content_type.id object.id reaction.value %}" href="#">{{ reaction.counter }}</a>{% else %}<span>{{ reaction.counter }}</span>{% endif %}
         <div class="reaction_tooltip small">{% if reaction.counter > 0 and reaction.counter > reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} and more reacted with {{ label }}{% endblocktrans %}{% elif reaction.counter > 0 and reaction.counter == reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} reacted with {{ label }}{% endblocktrans %}{% else %}{% blocktrans with label=reaction.label %}Nobody reacted yet with {{ label }}{% endblocktrans %}{% endif %}</div>
       </span>
       {% if not forloop.last %}&nbsp;&nbsp;&nbsp;{% endif %}

--- a/demos/project-stories/project_stories/templates/comments/themes/avatar_in_header/comment_reactions.html
+++ b/demos/project-stories/project_stories/templates/comments/themes/avatar_in_header/comment_reactions.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+{% load comments_ink %}
+
+{% with creactions=comment.get_reactions %}
+  {% if creactions.counter > 0 %}
+    <div class="active-reactions">
+      {% for reaction in creactions.list %}
+        {% if reaction.counter > 0 %}
+          <div class="reaction" data-reaction="{{ reaction.value }}">
+            {% if reaction.counter > max_users_in_tooltip %}<a data-modal-trigger aria-controls="list-reacted" aria-expanded="false" data-href="{% url 'comments-ink-list-reacted' comment.id reaction.value %}" href="#" class="smaller">{{ reaction.counter }}</a>{% else %}<span class="smaller">{{ reaction.counter }}</span>{% endif %}<span class="emoji">&{{ reaction.icon }};</span>
+            <div class="reaction_tooltip">{% if reaction.counter > reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} and more reacted with {{ label }}{% endblocktrans %}{% elif reaction.counter == reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} reacted with {{ label }}{% endblocktrans %}{% endif %}</div>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endwith %}

--- a/demos/project-stories/project_stories/templates/stories/story_detail.html
+++ b/demos/project-stories/project_stories/templates/stories/story_detail.html
@@ -10,6 +10,7 @@
 {% block extra_css %}
 <link rel="stylesheet" type="text/css" href="{% static 'django_comments_ink/css/comments.css' %}">
 <link rel="stylesheet" type="text/css" href="{% static 'django_comments_ink/css/reactions.css' %}">
+<link rel="stylesheet" type="text/css" href="{% static 'modal.css' %}">
 {% endblock %}
 
 {% block nav-stories-class %}active{% endblock %}
@@ -59,7 +60,20 @@
     </div>
   </article>
 </main>
-{% endblock %}
+{% endblock content %}
+
+{% block extra_html %}
+{% render_comment_reply_template for object %}
+{% render_comment_reactions_panel_template %}
+<section class="modal" id="list-reacted" data-modal-target>
+  <div class="modal__overlay" data-modal-close tabindex="-1"></div>
+  <div class="modal__wrapper">
+    <button class="modal__close" data-modal-close aria-label="Close Modal">&times;</button>
+    <div class="modal__content">
+    </div>
+  </div>
+</section>
+{% endblock extra_html %}
 
 {% block extra_js %}
 <script>
@@ -67,8 +81,6 @@
       enable_comment_reactions: true
     }
 </script>
-<script src="{% static 'django_comments_ink/dist/dci-0.0.1.js' %}"></script>
-
-{% render_comment_reply_template for object %}
-{% render_comment_reactions_panel_template %}
+<script src="{% static 'django_comments_ink/dist/dci-0.0.2.js' %}"></script>
+<script src="{% static 'modal.js' %}"></script>
 {% endblock %}

--- a/demos/project-stories/project_stories/templates/stories/story_detail.html
+++ b/demos/project-stories/project_stories/templates/stories/story_detail.html
@@ -67,11 +67,7 @@
 {% render_comment_reactions_panel_template %}
 <section class="modal" id="list-reacted" data-modal-target>
   <div class="modal__overlay" data-modal-close tabindex="-1"></div>
-  <div class="modal__wrapper">
-    <button class="modal__close" data-modal-close aria-label="Close Modal">&times;</button>
-    <div class="modal__content">
-    </div>
-  </div>
+  <div class="modal__wrapper"></div>
 </section>
 {% endblock extra_html %}
 

--- a/django_comments_ink/templates/comments/list_reacted.html
+++ b/django_comments_ink/templates/comments/list_reacted.html
@@ -9,7 +9,7 @@
 <main>
   <article>
     <div class="container">
-      <h2 class="text-center">{% blocktrans with reaction_icon=reaction.icon %}List of users that reacted with <span class="emoji">&{{ reaction_icon }}; <br/>to the comment:</span>{% endblocktrans %}</h2>
+      <h2 class="text-center">{% blocktrans with reaction_icon=reaction.icon %}List of users that reacted with <span class="emoji">&{{ reaction_icon }};</span><br/>to the comment:{% endblocktrans %}</h2>
     </div>
     <div class="central-column">
       <div class="{% dci_custom_selector %} pb32">

--- a/django_comments_ink/templates/comments/themes/avatar_in_header/comment_reactions.html
+++ b/django_comments_ink/templates/comments/themes/avatar_in_header/comment_reactions.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load comments_ink %}
 
 {% with creactions=comment.get_reactions %}

--- a/django_comments_ink/templates/comments/themes/feedback_in_header/comment.html
+++ b/django_comments_ink/templates/comments/themes/feedback_in_header/comment.html
@@ -15,7 +15,7 @@
         {% if not comment.is_removed %}
           {% if comment_reactions_enabled %}
             <div class="reactions" id="cm-reactions-{{ comment.id }}">
-              {% include "comments/themes/avatar_in_header/comment_reactions.html" %}
+              {% include "comments/themes/feedback_in_header/comment_reactions.html" %}
             </div>
           {% endif %}
           {% if comment_reactions_enabled and is_input_allowed %}

--- a/django_comments_ink/templates/comments/themes/feedback_in_header/comment_reactions.html
+++ b/django_comments_ink/templates/comments/themes/feedback_in_header/comment_reactions.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load comments_ink %}
 
 {% with creactions=comment.get_reactions %}
@@ -6,7 +7,7 @@
       {% for reaction in creactions.list %}
         {% if reaction.counter > 0 %}
           <div class="reaction" data-reaction="{{ reaction.value }}">
-            <span class="smaller">{{ reaction.counter }}</span><span class="emoji">&{{ reaction.icon }};</span>
+            {% if reaction.counter > max_users_in_tooltip %}<a href="{% url 'comments-ink-list-reacted' comment.id reaction.value %}" class="smaller">{{ reaction.counter }}</a>{% else %}<span class="smaller">{{ reaction.counter }}</span>{% endif %}<span class="emoji">&{{ reaction.icon }};</span>
             <div class="reaction_tooltip">{% if reaction.counter > reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} and more reacted with {{ label }}{% endblocktrans %}{% elif reaction.counter == reaction.authors|length %}{% blocktrans with authors=reaction.authors|join:", " label=reaction.label %}{{ authors }} reacted with {{ label }}{% endblocktrans %}{% endif %}</div>
           </div>
         {% endif %}

--- a/django_comments_ink/tests/test_templatetags.py
+++ b/django_comments_ink/tests/test_templatetags.py
@@ -1612,7 +1612,7 @@ def test_render_object_reactions_form_for_object_case_1(a_diary_entry):
     # Template object_reactions_form.html displays reactions,
     # regardless of whether the object received reactions or not.
 
-    span_counter = '<span style="color:#444">0</span>'
+    span_counter = "<span>0</span>"
     assert result.count(span_counter) == 2
 
     for item in get_object_reactions_enum():

--- a/django_comments_ink/views.py
+++ b/django_comments_ink/views.py
@@ -1364,6 +1364,7 @@ def list_reacted_to_object(request, content_type_id, object_pk, reaction_value):
         request,
         _list_reacted_to_object_tmpl,
         {
+            "content_type": ctype,
             "object": reaction.content_object,
             "reaction": get_object_reactions_enum()(reaction.reaction),
             "page_obj": page_obj,


### PR DESCRIPTION
Closes #15:

Use a modal window to display the list of users that sent a specific reaction:
 * List the users that reacted to an object (like a story)
 * List the users that reacted to a comment.

Only use the modal when the number of users exceed `settings.COMMENTS_INK_MAX_USERS_IN_TOOLTIP`.