### PR TITLE
Fix cache and add voting to theme avatar in thread

### DIFF
--- a/django_comments_ink/caching.py
+++ b/django_comments_ink/caching.py
@@ -22,6 +22,8 @@ def get_cache():
             settings.COMMENTS_INK_CACHE_NAME,
         )
         dci_cache = caches["default"]
+    except TypeError:
+        logger.info("COMMENTS_INK_CACHE_KEY=None => App cache is disabled.")
 
     return dci_cache
 
@@ -31,7 +33,7 @@ def clear_cache(content_type_id, object_pk, site_id):
     if dci_cache == None:
         logger.warning(
             "Cannot access the cache. Could not clear the cache "
-            "for content_type={%d}, object_pk={%d} and site_id={%d}. "
+            "for content_type={%d}, object_pk={%s} and site_id={%d}. "
             % (content_type_id, object_pk, site_id)
         )
         return False

--- a/django_comments_ink/paginator.py
+++ b/django_comments_ink/paginator.py
@@ -181,9 +181,15 @@ class CommentsPaginator(Paginator):
         if ptotal:
             inpage.append(ptotal)
         self.set_subkey_cache(inpage_subkey, inpage)  # Store it in cache.
-        logger.debug(
-            "in_page computed (saved in cache) %s: %s", self.ckey_prefix, inpage
-        )
+        if self.dci_cache:
+            logger.debug(
+                "in_page computed (saved in cache) %s: %s",
+                self.ckey_prefix,
+                inpage,
+            )
+        else:
+            logger.debug("in_page computed: %s", inpage)
+        print("At the end of in_page")
         return inpage
 
     def page(self, number):

--- a/django_comments_ink/static/django_comments_ink/css/reactions.css
+++ b/django_comments_ink/static/django_comments_ink/css/reactions.css
@@ -166,6 +166,15 @@ BUTTON.emoji {
     font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
+.vote-score {
+    padding: 1px 8px;
+    font-size: 1.0rem;
+    font-weight: bold;
+    color: white;
+    background-color: #f66;
+    border-radius: 4px;
+}
+
 /* ----------------------------------------------------- */
 .users-grid {
     display: grid;

--- a/django_comments_ink/templates/comments/comment.html
+++ b/django_comments_ink/templates/comments/comment.html
@@ -8,7 +8,22 @@
   <div class="comment">
     <div class="header">
       <div>
-        {% if not comment.is_removed and comment_votes_enabled and is_input_allowed and comment.level == 0 %}<div style="display:inline-block"><a href="{% url 'comments-ink-vote' comment.id %}?{% render_qs_params page page_obj.number %}#{{ anchor }}">&bigtriangleup;</a>&nbsp;<span style="font-size: 1.0rem; color: #666;">{{ comment.thread.score }}</span>&nbsp;<a href="{% url 'comments-ink-vote' comment.id %}?{% render_qs_params page page_obj.number %}#{{ anchor }}">&bigtriangledown;</a></div>&nbsp;&sdot;&nbsp;{% endif %}{% if comment.url and not comment.is_removed %}<a href="{{ comment.url }}" target="_new">{{ comment.name }}</a>{% else %}{{ comment.name }}{% endif %}&nbsp;&sdot;&nbsp;<span class="muted">{{ comment.submit_date }}</span>&nbsp;&nbsp;<a class="permalink" title="comment permalink" href="{% get_inkcomment_permalink comment page_number %}">¶</a>
+        {% if not comment.is_removed and comment_votes_enabled and is_input_allowed and comment.level == 0 %}
+          <div style="display:inline-block">
+            {% if is_input_allowed %}<a href="{% url 'comments-ink-vote' comment.id %}?{% render_qs_params page page_obj.number %}#{{ anchor }}" class="smaller">&bigtriangleup;</a>{% endif %}
+            <span class="vote-score">{{ comment.thread.score }}{% if not is_input_allowed %}{% trans "points" %}{% endif %}</span>
+            {% if is_input_allowed %}<a href="{% url 'comments-ink-vote' comment.id %}?{% render_qs_params page page_obj.number %}#{{ anchor }}" class="smaller">&bigtriangledown;</a>{% endif %}
+          </div>
+          &sdot;
+        {% endif %}
+        {% if comment.url and not comment.is_removed %}
+          <a href="{{ comment.url }}" target="_new">{{ comment.name }}</a>
+        {% else %}
+          {{ comment.name }}
+        {% endif %}
+        &sdot;
+        <span class="muted">{{ comment.submit_date }}</span>
+        <a class="permalink" title="comment permalink" href="{% get_inkcomment_permalink comment page_number %}">¶</a>
       </div>
       {% if not comment.is_removed and comment_flagging_enabled and is_input_allowed %}<div class="small"><a href="{% url 'comments-flag' comment.id %}">report</a></div>{% endif %}
     </div>

--- a/django_comments_ink/templates/comments/themes/avatar_in_header/comment.html
+++ b/django_comments_ink/templates/comments/themes/avatar_in_header/comment.html
@@ -7,6 +7,15 @@
   {{ comment.level|indent_divs }}
   <div class="comment">
     <div class="header flex-align-center">
+      {% if not comment.is_removed and comment_votes_enabled and is_input_allowed and comment.level == 0 %}
+        <div class="flex-align-center">
+          <div style="padding-left: 2px; padding-right: 16px; display: flex; flex-direction: column; line-height: 1.2" class="flex-align-center">
+            {% if is_input_allowed %}<a href="{% url 'comments-ink-vote' comment.id %}?{% render_qs_params page page_obj.number %}#{{ anchor }}" class="smaller">&bigtriangleup;</a>{% endif %}
+            <span class="vote-score">{{ comment.thread.score }}{% if not is_input_allowed %}{% trans "points" %}{% endif %}</span>
+            {% if is_input_allowed %}<a href="{% url 'comments-ink-vote' comment.id %}?{% render_qs_params page page_obj.number %}#{{ anchor }}" class="smaller">&bigtriangledown;</a>{% endif %}
+          </div>
+        </div>
+      {% endif %}
       <div class="user-avatar flex-align-center">
         {% get_user_avatar_or_gravatar comment.user_email "36,identicon" %}
       </div>


### PR DESCRIPTION
This PR allows to disable the cache in django-comments-ink by making the setting `COMMENTS_INK_CACHE_NAME` = `None`. It also implements comment voting in the comment.html template of the theme `feedback_in_header`.