### PR TITLE
Add content_type to context to match template used in dci-project-stories

### DIFF
--- a/django_comments_ink/views/reacting.py
+++ b/django_comments_ink/views/reacting.py
@@ -348,6 +348,8 @@ class ReactedToObjectUserListView(ListView):
             raise Http404(_("Not enough users"))
 
         context = self.get_context_data(
-            object=self.reaction.content_object, reaction=reaction_enum
+            object=self.reaction.content_object,
+            reaction=reaction_enum,
+            content_type=self.ctype,
         )
         return self.render_to_response(context)


### PR DESCRIPTION
This PR goes together with https://github.com/comments-ink/dci-project-stories/pull/7

The js modal referred to [here](https://github.com/comments-ink/django-comments-ink/discussions/59#discussioncomment-9046022) seems to be using a template that also needs the `content_type` in the context.